### PR TITLE
Hybrid docker compose updates

### DIFF
--- a/docker-compose-deps.yml
+++ b/docker-compose-deps.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   redis:
     image: redis:6.2-alpine

--- a/docker-compose-deps.yml
+++ b/docker-compose-deps.yml
@@ -19,5 +19,6 @@ services:
     image: clamav/clamav
     ports:
       - 33100:3310
+    platform: linux/amd64
 volumes:
  shared-vol:

--- a/docker-compose-deps.yml
+++ b/docker-compose-deps.yml
@@ -4,6 +4,7 @@ services:
     ports:
       - "63790:6379"
   postgres:
+    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all -c max_connections=200
     image: postgis/postgis:14-3.3-alpine
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-password}"


### PR DESCRIPTION
## Summary

### ClamAV on M1 Mac
When following the instructions for [hybrid setup](https://github.com/department-of-veterans-affairs/vets-api/blob/master/docs/setup/hybrid.md#running-deps) using my m1 Mac, I ran `docker-compose -f docker-compose-deps.yml up` and saw the error:
```
clamav Error no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found
Error response from daemon: no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest:
not found
```

<img width="2744" height="176" alt="image" src="https://github.com/user-attachments/assets/954af17c-d714-455d-8753-7d2d24754d05" />


[clamav/clamav/](https://hub.docker.com/r/clamav/clamav/tags) is only available for `linux/amd64`, so we can specify that as a platform in the docker-compose-deps.yml to prevent errors on other platforms. 

### remove docker compose version
I removed the obsolete `version` attribute.  The console messages reminds us to remove it.
`WARN[0000] /Users/annacarey/code/va/vets-api/docker-compose-deps.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
`
 
### Enable pg_stat_statements
As we do in our `docker-compose.yml` I enabled `pg_stat_statements` so that we can use PgHero with our docker hybrid dbs.

## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*

## Testing done

I verified the docker-compose-deps.yml locally. 

I no longer see the platform error when I run `docker-compose -f docker-compose-deps.yml up`
I no longer see a message suggesting I enable query stats at the bottom of pghero. 
I no longer see a version warning when I start docker. 

## Screenshots
_Note: Optional_

## What areas of the site does it impact?
* development

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x]  No error nor warning in the console.
- [ x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature

