### PR TITLE
Add gs to Brewfile for tests to pass locally

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,10 +1,11 @@
 brew 'clamav' # anti-virus scanner
 brew 'coreutils' # gnu coreutils
 brew 'docker-compose'
-brew 'imagemagick'
+brew 'imagemagick@6'
 brew 'memcached'
 brew 'poppler' # pdf rendering
 brew 'redis'
+brew 'gs'
 
 # Note: Installing psql@14 may be difficult to complete using Homebrew. See
 # docs/setup/native.md#OSX for more information. Included here for completeness.


### PR DESCRIPTION

## Summary

Affects local dev only - 

When I ran tests natively - I saw the following errors. 
There are two issues: 
1) we're not specifying a version for imagemagick, but it looks like we use ImageMagick-6 in our Dockerfile
2) ghost script (`gs`) isn't specified as a dependency.
```
`rspec './spec/lib/benefits_intake_service/utilities/convert_to_pdf_spec.rb
     MiniMagick::Error:
       `magick convert -resize 2550x3300 -density 300 tmp/196c66349455d7407019a09af9cbbf55.1761491766.converted_from_doctors-note-actual-jpg.jpg_cover_page.pdf spec/fixtures/files/doctors-note-actual-jpg.jpg tmp/196c66349455d7407019a09af9cbbf55.1761491766.converted_from_doctors-note-actual-jpg.jpg.pdf` failed with status: 1 and error:
       WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"

       sh: gs: command not found
       convert: FailedToExecuteCommand `'gs' -sstdout=%stderr -dQUIET -dSAFER -dBATCH -dNOPAUSE -dNOPROMPT -dMaxBitmap=500000000 -dAlignToPixels=0 -dGridFitTT=2 '-sDEVICE=png16malpha' -dTextAlphaBits=4 -dGraphicsAlphaBits=4 '-r300x300' -dPrinted=false  '-sOutputFile=/var/folders/l1/l0xxnk_j62q_czf2bwr9d3t40000gn/T/magick-2ilEnI4xdeYav-MUIHTTqol8B6YE8tHn%d' '-f/var/folders/l1/l0xxnk_j62q_czf2bwr9d3t40000gn/T/magick-WTs-OueWKpsxQUDqcrjcXJ9-h1Ud2R9K' '-f/var/folders/l1/l0xxnk_j62q_czf2bwr9d3t40000gn/T/magick-UyS0DwLSNEFznfunGrPp8jSbyUJqBoFb'' (32512) @ error/ghostscript-private.h/ExecuteGhostscriptCommand/75.
     # ./lib/benefits_intake_service/utilities/convert_to_pdf.rb:57:in `convert_img!'
     # ./lib/benefits_intake_service/utilities/convert_to_pdf.rb:27:in `initialize'
     # ./spec/lib/benefits_intake_service/utilities/convert_to_pdf_spec.rb:21:in `new'
     # ./spec/lib/benefits_intake_service/utilities/convert_to_pdf_spec.rb:21:in `block (4 levels) in <top (required)>'
```

## Related issue(s)

I don't have permission to make an issue.

## Testing done

this affects local dev only, 
I ran `brew bundle` and then `rspec './spec/lib/benefits_intake_service/utilities/convert_to_pdf_spec.rb` and the test passed


## What areas of the site does it impact?
Native development using homebrew
## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [ ]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature


