### PR TITLE
bump vets json schema

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,10 +74,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/vets-json-schema
-  revision: 0a3ddc2b647869ba38d0dcae2886a729b7dde13d
+  revision: dec5c9d969c5afd6a8cc7a97d220727af6ff77db
   branch: master
   specs:
-    vets_json_schema (25.2.15)
+    vets_json_schema (25.2.20)
       multi_json (~> 1.0)
       script_utils (= 0.0.4)
 


### PR DESCRIPTION
- **(BIO) 21P-530a: PDF generation (#24914)**
- **(BIO) 21P-530a: OpenAPI Docs / Stubbed Endpoints (#24870)**
- **Chore: Resolve Shrine Image Warning (#24821)**
- **arp/prep_for_unique_representative_id_on_vsr (#24835)**
- **118645 append ids of active appts to referral details (#24665)**
- **[UHD] Remove per-domain lab type feature toggles and re-record cassettes (#24722)**
- **120766 notification emails dependents module (#24729)**
- **Chore: remove breakers_enabled? from MDOT configuration (#24834)**
- **Renames 10-7959c.yml to 10-7959C.yml (#24854)**
- **Fix fixture for failing spec (#24928)**
- **Bump aasm from 5.5.1 to 5.5.2 (#24792)**
- **bump vets-json-schema - adds 21-0779 21-2680 21P-8416**
