### PR TITLE
exclude lib/pdf_fill/forms/field_mappings/  from Danger line count

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -55,7 +55,7 @@ module VSPDanger
       *.csv *.json *.tsv *.txt *.md Gemfile.lock app/swagger modules/mobile/docs spec/fixtures/ spec/support/vcr_cassettes/
       modules/mobile/spec/support/vcr_cassettes/ db/seeds modules/vaos/app/docs modules/meb_api/app/docs
       modules/appeals_api/app/swagger/ *.bru *.pdf modules/*/spec/fixtures/* modules/*/spec/factories/*
-      modules/*/spec/**/*.rb spec/**/*.rb
+      modules/*/spec/**/*.rb spec/**/*.rb lib/pdf_fill/forms/field_mappings/*.rb
     ].freeze
     PR_SIZE = { recommended: 200, maximum: 500 }.freeze
 

--- a/app/services/sign_in/acr_translator.rb
+++ b/app/services/sign_in/acr_translator.rb
@@ -11,7 +11,7 @@ module SignIn
     end
 
     def perform
-      translate_acr
+      { acr: translate_acr, acr_comparison: translate_acr_comparison }.compact
     end
 
     private
@@ -29,6 +29,10 @@ module SignIn
       else
         raise Errors::InvalidTypeError.new message: 'Invalid Type value'
       end
+    end
+
+    def translate_acr_comparison
+      type == Constants::Auth::IDME && acr == 'min' ? Constants::Auth::IDME_COMPARISON_MINIMUM : nil
     end
 
     def translate_idme_values
@@ -69,7 +73,7 @@ module SignIn
       when 'ial2'
         Constants::Auth::LOGIN_GOV_IAL2
       when 'min'
-        uplevel ? Constants::Auth::LOGIN_GOV_IAL2 : Constants::Auth::LOGIN_GOV_IAL1
+        Constants::Auth::LOGIN_GOV_IAL0
       else
         raise Errors::InvalidAcrError.new message: 'Invalid ACR for logingov'
       end

--- a/app/services/sign_in/constants/auth.rb
+++ b/app/services/sign_in/constants/auth.rb
@@ -15,9 +15,11 @@ module SignIn
                           IDME_DSLOGON_LOA3 = 'dslogon_loa3',
                           IDME_MHV_LOA1 = 'myhealthevet',
                           IDME_MHV_LOA3 = 'myhealthevet_loa3',
+                          IDME_COMPARISON_MINIMUM = 'comparison:minimum',
                           MHV_PREMIUM_VERIFIED = %w[Premium].freeze,
                           DSLOGON_PREMIUM_VERIFIED = [DSLOGON_ASSURANCE_TWO = '2',
                                                       DSLOGON_ASSURANCE_THREE = '3'].freeze,
+                          LOGIN_GOV_IAL0 = 'http://idmanagement.gov/ns/assurance/ial/0',
                           LOGIN_GOV_IAL1 = 'http://idmanagement.gov/ns/assurance/ial/1',
                           LOGIN_GOV_IAL2 = 'http://idmanagement.gov/ns/assurance/ial/2'].freeze
       ANTI_CSRF_COOKIE_NAME = 'vagov_anti_csrf_token'

--- a/lib/sign_in/idme/service.rb
+++ b/lib/sign_in/idme/service.rb
@@ -22,12 +22,15 @@ module SignIn
         super()
       end
 
-      def render_auth(state: SecureRandom.hex, acr: Constants::Auth::IDME_LOA1, operation: Constants::Auth::AUTHORIZE)
-        scoped_acr = append_optional_scopes(acr)
+      def render_auth(state: SecureRandom.hex,
+                      acr: { acr: Constants::Auth::IDME_LOA1 },
+                      operation: Constants::Auth::AUTHORIZE)
+        scoped_acr = append_optional_scopes(acr[:acr])
         Rails.logger.info('[SignIn][Idme][Service] Rendering auth, ' \
                           "state: #{state}, acr: #{scoped_acr}, operation: #{operation}")
 
-        RedirectUrlGenerator.new(redirect_uri: auth_url, params_hash: auth_params(scoped_acr, state, operation)).perform
+        RedirectUrlGenerator.new(redirect_uri: auth_url,
+                                 params_hash: auth_params(scoped_acr, acr[:acr_comparison], state, operation)).perform
       end
 
       def normalized_attributes(user_info, credential_level)
@@ -65,15 +68,20 @@ module SignIn
 
       private
 
-      def auth_params(acr, state, operation)
+      def auth_params(acr, acr_comparison, state, operation)
         {
           scope: acr,
           state:,
           client_id: config.client_id,
           redirect_uri: config.redirect_uri,
           response_type: config.response_type,
+          acr_values: format_acr_comparison(acr_comparison),
           op: convert_operation(operation)
         }.compact
+      end
+
+      def format_acr_comparison(acr_comparison)
+        acr_comparison ? "#{acr_comparison} #{Constants::Auth::IDME_LOA1}" : nil
       end
 
       def convert_operation(operation)

--- a/lib/sign_in/logingov/service.rb
+++ b/lib/sign_in/logingov/service.rb
@@ -31,14 +31,14 @@ module SignIn
       end
 
       def render_auth(state: SecureRandom.hex,
-                      acr: Constants::Auth::LOGIN_GOV_IAL1,
+                      acr: { acr: Constants::Auth::LOGIN_GOV_IAL1 },
                       operation: Constants::Auth::AUTHORIZE)
         Rails.logger.info('[SignIn][Logingov][Service] Rendering auth, ' \
-                          "state: #{state}, acr: #{acr}, operation: #{operation}, " \
+                          "state: #{state}, acr: #{acr[:acr]}, operation: #{operation}, " \
                           "optional_scopes: #{optional_scopes}")
 
         scope = (DEFAULT_SCOPES + optional_scopes).join(' ')
-        RedirectUrlGenerator.new(redirect_uri: auth_url, params_hash: auth_params(acr, state, scope)).perform
+        RedirectUrlGenerator.new(redirect_uri: auth_url, params_hash: auth_params(acr[:acr], state, scope)).perform
       end
 
       def render_logout(client_logout_redirect_uri)

--- a/spec/lib/sign_in/idme/service_spec.rb
+++ b/spec/lib/sign_in/idme/service_spec.rb
@@ -60,6 +60,8 @@ describe SignIn::Idme::Service do
   let(:idme_originating_url) { 'https://api.idmelabs.com/oidc' }
   let(:state) { 'some-state' }
   let(:acr) { 'some-acr' }
+  let(:acr_comparison) { nil }
+  let(:acr_param) { { acr:, acr_comparison: }.compact }
   let(:idme_client_id) { 'ef7f1237ed3c396e4b4a2b04b608a7b1' }
   let(:user_uuid) { '88f572d491af46efa393cba6c351e252' }
   let(:birth_date) { '1932-02-05' }
@@ -82,7 +84,7 @@ describe SignIn::Idme::Service do
   end
 
   describe '#render_auth' do
-    let(:response) { subject.render_auth(state:, acr:, operation:).to_s }
+    let(:response) { subject.render_auth(state:, acr: acr_param, operation:).to_s }
     let(:expected_authorization_page) { "#{base_path}/#{auth_path}" }
     let(:base_path) { 'some-base-path' }
     let(:auth_path) { 'oauth/authorize' }
@@ -148,6 +150,16 @@ describe SignIn::Idme::Service do
         it 'does not include the optional scopes in the request' do
           expect(response).not_to include(CGI.escape('/invalid_scope'))
         end
+      end
+    end
+
+    context 'when acr_comparison is provided in acr param' do
+      let(:acr_comparison) { 'some-acr-comparison' }
+      let(:encoded_acr_value) { CGI.escape(SignIn::Constants::Auth::IDME_LOA1) }
+      let(:expected_acr_values) { "acr_values=some-acr-comparison+#{encoded_acr_value}" }
+
+      it 'includes acr_values param in rendered form' do
+        expect(response).to include(expected_acr_values)
       end
     end
   end

--- a/spec/lib/sign_in/logingov/service_spec.rb
+++ b/spec/lib/sign_in/logingov/service_spec.rb
@@ -48,13 +48,14 @@ describe SignIn::Logingov::Service do
   let(:expected_authorization_page) { 'https://idp.int.identitysandbox.gov/openid_connect/authorize' }
   let(:state) { 'some-state' }
   let(:acr) { 'some-acr' }
+  let(:acr_param) { { acr: } }
   let(:operation) { 'some-operation' }
   let(:optional_scopes) { ['all_emails'] }
   let(:current_time) { 1_692_663_038 }
   let(:expiration_time) { 1_692_663_938 }
 
   describe '#render_auth' do
-    let(:response) { subject.render_auth(state:, acr:, operation:).to_s }
+    let(:response) { subject.render_auth(state:, acr: acr_param, operation:).to_s }
     let(:expected_scopes) { ['profile', 'profile:verified_at', 'address', 'email', 'openid', 'social_security_number'] }
     let(:expected_scope_query) { "scope=#{CGI.escape(expected_scopes.join(' '))}" }
     let(:expected_optional_scopes) { described_class::OPTIONAL_SCOPES & optional_scopes }

--- a/spec/services/sign_in/acr_translator_spec.rb
+++ b/spec/services/sign_in/acr_translator_spec.rb
@@ -17,40 +17,41 @@ RSpec.describe SignIn::AcrTranslator do
 
       context 'and acr is loa1' do
         let(:acr) { 'loa1' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_LOA1 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_LOA1 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
       context 'and acr is loa3' do
         let(:acr) { 'loa3' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_LOA3_FORCE }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_LOA3_FORCE } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
       context 'and acr is min' do
         let(:acr) { 'min' }
+        let(:acr_comparison) { SignIn::Constants::Auth::IDME_COMPARISON_MINIMUM }
 
         context 'and uplevel is false' do
           let(:uplevel) { false }
-          let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_LOA1 }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_LOA1, acr_comparison: } }
 
           it 'returns expected translated acr value' do
-            expect(subject).to be(expected_translated_acr)
+            expect(subject).to eq(expected_translated_acr)
           end
         end
 
         context 'and uplevel is true' do
           let(:uplevel) { true }
-          let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_LOA3 }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_LOA3, acr_comparison: } }
 
           it 'returns expected translated acr value' do
-            expect(subject).to be(expected_translated_acr)
+            expect(subject).to eq(expected_translated_acr)
           end
         end
       end
@@ -71,19 +72,19 @@ RSpec.describe SignIn::AcrTranslator do
 
       context 'and acr is ial1' do
         let(:acr) { 'ial1' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL1 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL1 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
       context 'and acr is ial2' do
         let(:acr) { 'ial2' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL2 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
@@ -92,19 +93,19 @@ RSpec.describe SignIn::AcrTranslator do
 
         context 'and uplevel is false' do
           let(:uplevel) { false }
-          let(:expected_translated_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL1 }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL0 } }
 
           it 'returns expected translated acr value' do
-            expect(subject).to be(expected_translated_acr)
+            expect(subject).to eq(expected_translated_acr)
           end
         end
 
         context 'and uplevel is true' do
           let(:uplevel) { true }
-          let(:expected_translated_acr) { SignIn::Constants::Auth::LOGIN_GOV_IAL2 }
+          let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::LOGIN_GOV_IAL0 } }
 
           it 'returns expected translated acr value' do
-            expect(subject).to be(expected_translated_acr)
+            expect(subject).to eq(expected_translated_acr)
           end
         end
       end
@@ -125,29 +126,29 @@ RSpec.describe SignIn::AcrTranslator do
 
       context 'and acr is loa1' do
         let(:acr) { 'loa1' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_DSLOGON_LOA1 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_DSLOGON_LOA1 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
       context 'and acr is loa3' do
         let(:acr) { 'loa3' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_DSLOGON_LOA1 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_DSLOGON_LOA1 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
       context 'and acr is min' do
         let(:acr) { 'min' }
 
-        let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_DSLOGON_LOA1 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_DSLOGON_LOA1 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
@@ -167,28 +168,28 @@ RSpec.describe SignIn::AcrTranslator do
 
       context 'and acr is loa1' do
         let(:acr) { 'loa1' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_MHV_LOA1 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_MHV_LOA1 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
       context 'and acr is loa3' do
         let(:acr) { 'loa3' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_MHV_LOA1 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_MHV_LOA1 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 
       context 'and acr is min' do
         let(:acr) { 'min' }
-        let(:expected_translated_acr) { SignIn::Constants::Auth::IDME_MHV_LOA1 }
+        let(:expected_translated_acr) { { acr: SignIn::Constants::Auth::IDME_MHV_LOA1 } }
 
         it 'returns expected translated acr value' do
-          expect(subject).to be(expected_translated_acr)
+          expect(subject).to eq(expected_translated_acr)
         end
       end
 


### PR DESCRIPTION
## Summary
Dev config only - 
lib/pdf_fill/forms/field_mappings/ is more like config data than code. Therefore, I think it could/should be excluded from Danger bot for PR size. 

Take a look at https://github.com/department-of-veterans-affairs/vets-api/pull/24918/files#diff-e9f16dbfccef9b7e35d529c8d497c185760e6cd38bff783cfbca070e659652d8 for an example
## Related issue(s)

- *Link to ticket created in va.gov-team repo OR screenshot of Jira ticket if your team uses Jira*


## Testing done

This code only runs during CI - therefore this PR is enough testing

## What areas of the site does it impact?
PR workflow

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x]  No error nor warning in the console.
- [ ]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as expected
- [ ]  I added a screenshot of the developed feature
